### PR TITLE
Fixtoctree

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -23,7 +23,10 @@ Basic Installation
       extensions = ['sphinxcontrib.fulltoc']
       ...
       
-3. Rebuild all of the HTML output for your project.
+3. Rebuild all of the HTML output for your project.  Note that this
+   extension is incompatible with the :hidden: option to the
+   toctree directive
+   
 
 Advanced Use
 ============

--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -37,16 +37,19 @@ def html_page_context(app, pagename, templatename, context, doctree):
     context['toc'] = rendered_toc
     context['display_toc'] = True  # force toctree to display
 
-    def make_toctree(collapse=True):
+    def make_toctree(collapse=True,maxdepth=-1,includehidden=False):
         return get_rendered_toctree(app.builder,
                                     pagename,
                                     prune=False,
                                     collapse=collapse,
+                                    includehidden=includehidden,
+                                    maxdepth= maxdepth,
                                     )
     context['toctree'] = make_toctree
 
 
-def get_rendered_toctree(builder, docname, prune=False, collapse=True):
+def get_rendered_toctree(builder, docname, prune=False, collapse=True,maxdepth=-1,
+                         includehidden=False):
     """Build the toctree relative to the named document,
     with the given parameters, and then return the rendered
     HTML fragment.


### PR DESCRIPTION
sphinx 1.2 introduced the includehidden keyword, added to make_toctree
