### PR TITLE
Add check for toctree function, needed for json builder compatibility

### DIFF
--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -37,6 +37,9 @@ def html_page_context(app, pagename, templatename, context, doctree):
     context['toc'] = rendered_toc
     context['display_toc'] = True  # force toctree to display
 
+    if "toctree" not in context:
+        # json builder doesn't use toctree func, so nothing to replace
+        return
     def make_toctree(collapse=True):
         return get_rendered_toctree(app.builder,
                                     pagename,


### PR DESCRIPTION
I think this change fixes issue #10 - the json builder doesn't define a toctree function, and omitting the replacement if it wasn't already set seems to build correctly.
