### PR TITLE
Support :hidden: option to toctree directive

### DIFF
--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -71,6 +71,7 @@ def build_full_toctree(builder, docname, prune, collapse):
         toctree = env.resolve_toctree(docname, builder, toctreenode,
                                       collapse=collapse,
                                       prune=prune,
+                                      includehidden=True,
                                       )
         if toctree is not None:
             toctrees.append(toctree)

--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -72,7 +72,9 @@ def build_full_toctree(builder, docname, prune, collapse):
                                       collapse=collapse,
                                       prune=prune,
                                       )
-        toctrees.append(toctree)
+        if toctree is not None:
+            toctrees.append(toctree)
+
     if not toctrees:
         return None
     result = toctrees[0]


### PR DESCRIPTION
Ensures that `:hidden:` option does not cause an exception, and also sets `includehidden=True` to populate the sidebar TOC with the full TOC in line with expectations of just hiding the output in the main page layout.