### PR TITLE
add missing keywords to make_toctree

### DIFF
--- a/sphinxcontrib/fulltoc.py
+++ b/sphinxcontrib/fulltoc.py
@@ -40,7 +40,7 @@ def html_page_context(app, pagename, templatename, context, doctree):
     if "toctree" not in context:
         # json builder doesn't use toctree func, so nothing to replace
         return
-    def make_toctree(collapse=True):
+    def make_toctree(collapse=True, maxdepth=-1, includehidden=True):
         return get_rendered_toctree(app.builder,
                                     pagename,
                                     prune=False,


### PR DESCRIPTION
rtd requires being able to pass through values for maxdepth and
includehidden, make the keywords available in the initial method even
though they will be subsequently ignored.